### PR TITLE
fix issue with obtaining and releasing locks

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,14 +39,15 @@ import (
 // ...
 
 certmagic.Default.Storage = &dynamodbstore.DynamoDBStorage{
-    Table:               "CertMagic",
-    LockTimeout:         2 * time.Minute // optional: default is 5 minutes
-    LockPollingInterval: 2 * time.Second // optional: default is 5 seconds
+    TableName:             "CertMagic",
+    LockTimeout:           2 * time.Minute // optional: default is 1 minute
+    LockFreshnessInterval: 10 * time.Second // optional: default is 10 seconds
+    LockPollingInterval:   4 * time.Second // optional: default is 1 second
 }
 
 // ...
 ```
-Only the table name is required, but you can also override the default values for `LockTimeout` and 
+Only the table name is required, but you can also override the default values for `LockTimeout`, `LockFreshnessInterval` and 
 `LockPollingTimeout` if you want. Technically you can also override `AwsEndpoint`, `AwsRegion`, and 
 `AwsDisableSSL` if you are running your own DynamoDB service. These settings are used in the unit tests
 so you can look there for examples. 
@@ -58,6 +59,8 @@ and just run the tests from your local system, just be sure to adjust the `AWS_E
 variable to point to where you have `dynamodb-local` running. 
 
 ## Creating the DynamoDB Table 
+
+Note that only single region tables are supported.  Global tables or custom multi-region setups should work, but may experience locking issues due to the eventually consistent nature of DynamoDB.
 
 ### Command line:
 ```

--- a/caddy.go
+++ b/caddy.go
@@ -36,7 +36,7 @@ func (s *Storage) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 		if !d.NextArg() {
 			return d.ArgErr()
 		}
-		s.Table = d.Val()
+		s.TableName = d.Val()
 
 		for nesting := d.Nesting(); d.NextBlock(nesting); {
 			switch d.Val() {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,8 @@ module github.com/silinternational/certmagic-storage-dynamodb/v2
 go 1.13
 
 require (
-	github.com/aws/aws-sdk-go v1.30.20
+	github.com/aws/aws-sdk-go v1.35.17
 	github.com/caddyserver/caddy/v2 v2.0.0
 	github.com/caddyserver/certmagic v0.11.0
+	github.com/guregu/dynamo v1.10.0
 )

--- a/go.sum
+++ b/go.sum
@@ -99,6 +99,8 @@ github.com/aws/aws-sdk-go v1.23.0 h1:ilfJN/vJtFo1XDFxB2YMBYGeOvGZl6Qow17oyD4+Z9A
 github.com/aws/aws-sdk-go v1.23.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.30.20 h1:ktsy2vodSZxz/arYqo7DlpkIeNohHL+4Rmjdo7YGtrE=
 github.com/aws/aws-sdk-go v1.30.20/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
+github.com/aws/aws-sdk-go v1.35.17 h1:zhahppAMdPvJ9GP302SMOPW5SNoAbnjdOyaTmxA9WJU=
+github.com/aws/aws-sdk-go v1.35.17/go.mod h1:tlPOdRjfxPBpNIwqDj61rmsnA85v9jc0Ps9+muhnW+k=
 github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f/go.mod h1:AuiFmCCPBSrqvVMvuqFuk0qogytodnVFVSN5CeJB8Gc=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -113,6 +115,8 @@ github.com/caddyserver/caddy/v2 v2.0.0/go.mod h1:D2SD9GmjranT43H5Wa+tl4Yk0242e5X
 github.com/caddyserver/certmagic v0.10.12/go.mod h1:Y8jcUBctgk/IhpAzlHKfimZNyXCkfGgRTC0orl8gROQ=
 github.com/caddyserver/certmagic v0.11.0 h1:b7moj2Z/+iMa6x42V2L1AqbvHGti0aWGx2l7PkoERdQ=
 github.com/caddyserver/certmagic v0.11.0/go.mod h1:fqY1IZk5iqhsj5FU3Vw20Sjq66tEKaanTFYNZ74soMY=
+github.com/cenkalti/backoff v2.1.1+incompatible h1:tKJnvO2kl0zmb/jA5UKAt4VoEVw1qxKWjE/Bpp46npY=
+github.com/cenkalti/backoff v2.1.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.0.0 h1:6VeaLF9aI+MAUQ95106HwWzYZgJJpZ4stumjj6RFYAU=
 github.com/cenkalti/backoff/v4 v4.0.0/go.mod h1:eEew/i+1Q6OrCDZh3WiXYv3+nJwBASZ8Bog/87DQnVg=
 github.com/census-instrumentation/opencensus-proto v0.2.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -213,6 +217,7 @@ github.com/go-toolsmith/strparse v1.0.0/go.mod h1:YI2nUKP9YGZnL/L1/DLFBfixrcjslW
 github.com/go-toolsmith/typep v1.0.0/go.mod h1:JSQCQMUPdRlMZFswiq3TGpNp1GMktqkR2Ns5AIQkATU=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/gofrs/flock v0.0.0-20190320160742-5135e617513b/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
+github.com/gofrs/uuid v3.2.0+incompatible h1:y12jRkkFxsd7GpqdSZ+/KCs/fJbqpEXSGd4+jfEaewE=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -308,6 +313,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.5.0/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpg
 github.com/grpc-ecosystem/grpc-gateway v1.8.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.12.1/go.mod h1:8XEsbTttt/W+VvjtQhLACqCisSPWTxCZ7sBRjU6iH9c=
+github.com/guregu/dynamo v1.10.0 h1:zG+xzoingRP/8xw6ty6rbwotoU4sF+BlV43kiofc+Fs=
+github.com/guregu/dynamo v1.10.0/go.mod h1:8N+9X6a9mDtJ0n2DWVFR5PgTBSA4639ydOq2McTMvIc=
 github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542/go.mod h1:Ow0tF8D4Kplbc8s8sSb3V2oUCygFHVp8gC3Dn6U4MNI=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
@@ -327,6 +334,9 @@ github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5i
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2yCeUc=
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
+github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.5/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=


### PR DESCRIPTION
fixes #15

first... this is the first time i've ever touched go.  some more experienced eyes would be much appreciated.

summary of changes:
- added dynamo for interacting with ddb, which is a PITA in the best of times
- removed separate `LOCK-*` ddb records. Lock is now a property of the main `Item` record. this means there is no longer a need to document TTL because there is no longer a need for it at all
- switched to the same "active locking" functionality that file storage supports. added idempotent ddb updates to support it
- decreased timeouts to better service _on demand_ generation. (is LockTimeout too low now though? 1m)
- added documentation about single region support

~~there is one breaking change: i renamed "Table" -> "TableName" without good reason.~~ the rename doesn't impact use. the name in caddy config remains "table".

i did have to make some small modifications to tests because some stuff was renamed or removed.  otherwise though tests are unchanged and pass. some additional tests would be great but i don't really know how to do that.

