### PR TITLE
Enhance locking with atomic acquisition and refresh

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.39.6
 	github.com/caddyserver/caddy/v2 v2.8.1
 	github.com/caddyserver/certmagic v0.21.2
+	github.com/google/uuid v1.6.0
 )
 
 require (
@@ -30,7 +31,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
 	github.com/google/pprof v0.0.0-20240528025155-186aa0362fba // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.7 // indirect
 	github.com/libdns/libdns v0.2.2 // indirect

--- a/storage.go
+++ b/storage.go
@@ -315,7 +315,7 @@ func (s *Storage) Lock(ctx context.Context, key string) error {
 
 		// Lock acquired successfully
 		if err == nil {
-			lockCtx, cancel := context.WithCancel(context.Background())
+			lockCtx, cancel := context.WithCancel(ctx)
 			lockHandle := &LockHandle{
 				Key:        key,
 				LockID:     lockID,

--- a/storage.go
+++ b/storage.go
@@ -7,7 +7,10 @@ import (
 	"fmt"
 	"io/fs"
 	"log"
+	"sync"
 	"time"
+
+	"github.com/google/uuid"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -23,6 +26,8 @@ const (
 	contentsAttribute    = "Contents"
 	primaryKeyAttribute  = "PrimaryKey"
 	lastUpdatedAttribute = "LastUpdated"
+	lockIdAttribute      = "LockID"
+	expiresAtAttribute   = "ExpiresAt"
 	lockTimeoutMinutes   = caddy.Duration(5 * time.Minute)
 	lockPollingInterval  = caddy.Duration(5 * time.Second)
 )
@@ -62,6 +67,18 @@ type Storage struct {
 
 	// LockPollingInterval - [optional] how often to check for lock released. Default: 5 seconds
 	LockPollingInterval caddy.Duration `json:"lock_polling_interval,omitempty"`
+
+	// LockRefreshInterval - [optional] how often to refresh the lock. Default: LockTimeout / 3
+	LockRefreshInterval caddy.Duration `json:"lock_refresh_interval,omitempty"`
+
+	locks *sync.Map // map[string]*LockHandle
+}
+
+// LockHandle holds the information of a lock
+type LockHandle struct {
+	Key        string
+	LockID     string             // UUID to identify the lock
+	cancelFunc context.CancelFunc // Function to cancel periodic refresh
 }
 
 // initConfig initializes configuration for table name and AWS client
@@ -75,6 +92,9 @@ func (s *Storage) initConfig(ctx context.Context) error {
 	}
 	if s.LockPollingInterval == 0 {
 		s.LockPollingInterval = lockPollingInterval
+	}
+	if s.LockRefreshInterval == 0 {
+		s.LockRefreshInterval = s.LockTimeout / 3
 	}
 
 	// Initialize AWS Client if needed
@@ -92,6 +112,11 @@ func (s *Storage) initConfig(ctx context.Context) error {
 			o.EndpointOptions.DisableHTTPS = s.AwsDisableSSL
 		})
 	}
+
+	if s.locks == nil {
+		s.locks = &sync.Map{}
+	}
+
 	return nil
 }
 
@@ -268,42 +293,111 @@ func (s *Storage) Lock(ctx context.Context, key string) error {
 	}
 
 	lockKey := fmt.Sprintf("LOCK-%s", key)
+	lockID := uuid.NewString()
+	expiresAt := time.Now().Add(time.Duration(s.LockTimeout)).Unix()
 
-	// Check for existing lock
 	for {
-		existing, err := s.getItem(ctx, lockKey)
-		isErrNotExists := errors.Is(err, fs.ErrNotExist)
-		if err != nil && !isErrNotExists {
-			return err
+		// Acquire lock if it doesn't exist or expired
+		input := &dynamodb.PutItemInput{
+			TableName: aws.String(s.Table),
+			Item: map[string]types.AttributeValue{
+				primaryKeyAttribute: &types.AttributeValueMemberS{Value: lockKey},
+				lockIdAttribute:     &types.AttributeValueMemberS{Value: lockID},
+				expiresAtAttribute:  &types.AttributeValueMemberN{Value: fmt.Sprintf("%d", expiresAt)},
+			},
+			ConditionExpression: aws.String(fmt.Sprintf("attribute_not_exists(%s) OR %s < :now", primaryKeyAttribute, expiresAtAttribute)),
+			ExpressionAttributeValues: map[string]types.AttributeValue{
+				":now": &types.AttributeValueMemberN{Value: fmt.Sprintf("%d", time.Now().Unix())},
+			},
 		}
 
-		// if lock doesn't exist or is empty, break to create a new one
-		if isErrNotExists || existing.Contents == "" {
-			break
-		}
+		_, err := s.Client.PutItem(ctx, input)
 
-		// Lock exists, check if expired or sleep 5 seconds and check again
-		expires, err := time.Parse(time.RFC3339, existing.Contents)
-		if err != nil {
-			return err
-		}
-		if time.Now().After(expires) {
-			if err := s.Unlock(ctx, key); err != nil {
-				return err
+		// Lock acquired successfully
+		if err == nil {
+			lockCtx, cancel := context.WithCancel(context.Background())
+			lockHandle := &LockHandle{
+				Key:        key,
+				LockID:     lockID,
+				cancelFunc: cancel,
 			}
-			break
+			s.locks.Store(key, lockHandle)
+
+			// Start periodic refresh
+			go s.keepLockFresh(lockCtx, lockHandle)
+
+			return nil
 		}
 
+		// Lock not acquired, retry
 		select {
 		case <-time.After(time.Duration(s.LockPollingInterval)):
+			continue
 		case <-ctx.Done():
 			return ctx.Err()
 		}
 	}
+}
 
-	// lock doesn't exist, create it
-	contents := []byte(time.Now().Add(time.Duration(s.LockTimeout)).Format(time.RFC3339))
-	return s.Store(ctx, lockKey, contents)
+// keepLockFresh periodically updates the lock expiration
+// to prevent it from expiring while the critical section
+// is still running.
+func (s *Storage) keepLockFresh(ctx context.Context, handle *LockHandle) {
+	ticker := time.NewTicker(time.Duration(s.LockRefreshInterval))
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			if err := s.updateLockExpiration(ctx, handle); err != nil {
+				// The critical section should be aborted if lock refresh fails.
+				// However, there is no way to notify the critical section to abort,
+				// so we just log the error and stop refreshing the lock.
+				log.Printf("failed to update lock expiration for key %s: %v", handle.Key, err)
+				return
+			}
+		case <-ctx.Done():
+			return // Unlock or external cancellation
+		}
+	}
+}
+
+// updateLockExpiration updates the lock expiration atomically.
+func (s *Storage) updateLockExpiration(ctx context.Context, handle *LockHandle) error {
+	lockKey := fmt.Sprintf("LOCK-%s", handle.Key)
+	newExpiresAt := time.Now().Add(time.Duration(s.LockTimeout)).Unix()
+
+	// Check LockID in ConditionExpression and update only the lock created by itself
+	input := &dynamodb.UpdateItemInput{
+		TableName: aws.String(s.Table),
+		Key: map[string]types.AttributeValue{
+			primaryKeyAttribute: &types.AttributeValueMemberS{Value: lockKey},
+		},
+		UpdateExpression:    aws.String(fmt.Sprintf("SET %s = :newExpiresAt", expiresAtAttribute)),
+		ConditionExpression: aws.String(fmt.Sprintf("%s = :lockID", lockIdAttribute)),
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":newExpiresAt": &types.AttributeValueMemberN{Value: fmt.Sprintf("%d", newExpiresAt)},
+			":lockID":       &types.AttributeValueMemberS{Value: handle.LockID},
+		},
+	}
+
+	var err error
+	for range 3 { // Simple retry logic (up to 3 times)
+		_, err = s.Client.UpdateItem(ctx, input)
+		if err == nil {
+			return nil // Update successful
+		}
+
+		var ccfe *types.ConditionalCheckFailedException
+		if errors.As(err, &ccfe) {
+			// Do not retry if lock deleted or acquired by another process
+			return fmt.Errorf("failed to update lock expiration: lock may have been deleted or updated by another process")
+		}
+
+		// Retry in case of network error or other transient issues
+		time.Sleep(1 * time.Second)
+	}
+	return fmt.Errorf("failed to update lock expiration after retries: %w", err)
 }
 
 // Unlock releases the lock for key. This method must ONLY be
@@ -317,7 +411,39 @@ func (s *Storage) Unlock(ctx context.Context, key string) error {
 
 	lockKey := fmt.Sprintf("LOCK-%s", key)
 
-	return s.Delete(ctx, lockKey)
+	handle, ok := s.locks.LoadAndDelete(key)
+	if !ok {
+		return fmt.Errorf("no lock handle found for key: %s", key)
+	}
+	lockHandle, _ := handle.(*LockHandle)
+
+	// Stop periodic refresh of lock expiration
+	lockHandle.cancelFunc()
+
+	// Delete lock only if it was created by itself
+	input := &dynamodb.DeleteItemInput{
+		TableName: aws.String(s.Table),
+		Key: map[string]types.AttributeValue{
+			primaryKeyAttribute: &types.AttributeValueMemberS{Value: lockKey},
+		},
+		ConditionExpression: aws.String(fmt.Sprintf("%s = :lockID", lockIdAttribute)),
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":lockID": &types.AttributeValueMemberS{Value: lockHandle.LockID},
+		},
+	}
+
+	_, err := s.Client.DeleteItem(ctx, input)
+
+	if err != nil {
+		var ccfe *types.ConditionalCheckFailedException
+		if errors.As(err, &ccfe) {
+			// Lock already deleted or updated by another process
+			return fmt.Errorf("failed to unlock: lock may have been deleted or updated by another process")
+		}
+		return err
+	}
+
+	return nil
 }
 
 func (s *Storage) getItem(ctx context.Context, key string) (Item, error) {

--- a/storage_test.go
+++ b/storage_test.go
@@ -351,7 +351,7 @@ func TestDynamoDBStorage_Delete(t *testing.T) {
 	}
 }
 
-func TestDynamoDBStorage_LockConsistency(t *testing.T) {
+func TestDynamoDBStorageLockConsistency(t *testing.T) {
 	err := initDb()
 	if err != nil {
 		t.Error(err)
@@ -413,7 +413,7 @@ func TestDynamoDBStorage_LockConsistency(t *testing.T) {
 	}
 }
 
-func TestDynamoDBStorage_StaleLock(t *testing.T) {
+func TestDynamoDBStorageStaleLock(t *testing.T) {
 	err := initDb()
 	if err != nil {
 		t.Error(err)
@@ -468,7 +468,7 @@ func TestDynamoDBStorage_StaleLock(t *testing.T) {
 	}
 }
 
-func TestDynamoDBStorage_UnlockNonExistantKey(t *testing.T) {
+func TestDynamoDBStorageUnlockNonExistantKey(t *testing.T) {
 	err := initDb()
 	if err != nil {
 		t.Error(err)

--- a/storage_test.go
+++ b/storage_test.go
@@ -112,7 +112,7 @@ func TestDynamoDBStorage_initConfg(t *testing.T) {
 			}
 			// unset client since it is too complicated for reflection testing
 			s.Client = nil
-			// unset locks since it is a pointer and will always be different
+			// unset locks since sync.Map is not comparable
 			s.locks = nil
 			if !reflect.DeepEqual(tt.expected, s) {
 				t.Errorf("Expected does not match actual: %+v != %+v.", tt.expected, s)


### PR DESCRIPTION
### Overview

This PR introduces crucial changes to enhance the reliability and robustness of the locking mechanism. Specifically, it adds the functionality to make lock acquisition atomic and to periodically refresh the lock's expiration time. These changes reduce the risk of race conditions in concurrent environments, leading to more stable certificate management.

### Key Changes

#### 1. Atomic Lock Acquisition Logic:

-   In the previous implementation, checking for lock existence and creating the lock were separate steps, which could allow another process to acquire the lock in between.
-   The new implementation uses DynamoDB's `PutItem` operation with a `ConditionExpression` to make lock existence check and creation atomic.
-   By combining the `attribute_not_exists` and `ExpiresAt` conditions, the lock is only acquired if it does not exist or if it exists but has expired.
-   Furthermore, each lock is assigned a unique UUID (`LockID`), and the `UpdateItem` operation's `ConditionExpression` checks the `LockID` to ensure that only the lock created by itself can be updated.

#### 2. Periodic Lock Expiration Refresh:

-   The previous implementation had a fixed lock expiration time, which could lead to the lock expiring if the critical section took too long.
-   The new implementation starts a goroutine within the `Lock` method to periodically refresh the lock's expiration time at `LockRefreshInterval` (defaulting to `LockTimeout` / 3).
-   This ensures that the lock is held until the critical section's process is complete.

### Problems Solved and Benefits of the Changes

-   **Race Condition Prevention:** Atomic lock acquisition prevents race conditions where multiple processes attempt to acquire the lock simultaneously.
-   **Critical Section Protection:** Periodic lock refreshes prevent other instances from entering the critical section at the same time due to the lock expiring during the execution of the critical section. This prevents situations like:
    1.  An instance acquires the lock and enters the critical section.
    2.  The critical section's processing takes a long time, and the lock expires.
    3.  Another instance acquires the lock and enters the critical section simultaneously.
    4.  As a result, unexpected behavior occurs (for example, the certificate issuance process in the instance that first acquired the lock may stall).
-   **Improved Reliability:** A more robust locking mechanism improves the reliability of certificate acquisition and renewal processes.
-   **Improved Stability in Clustered Environments:**  More stable behavior is expected, especially in clustered environments where multiple application instances share DynamoDB.

Please let me know if you have any questions or concerns. I'm looking forward to your feedback and the opportunity to contribute to this project.