### PR TITLE
Enable latest check for govulncheck workflow

### DIFF
--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -11,7 +11,7 @@ jobs:
   govulncheck:
     uses: sil-org/workflows/.github/workflows/govulncheck.yaml@main
     with:
-      check-latest: false
+      check-latest: true
       go-version-file: './go.mod'
       go-version-input: ''
       work-dir: '.'


### PR DESCRIPTION
Enable the `check-latest` input on the govulncheck workflow to avoid reporting vulnerabilites related to Go patch levels since this is a library and clients can manage their own Go patch version as necessary.